### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [8/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ipmi.json
+++ b/chef/data_bags/crowbar/bc-template-ipmi.json
@@ -12,6 +12,9 @@
   "deployment": {
     "ipmi": {
       "crowbar-revision": 0,
+      "element_states": {
+        "ipmi-configure": [ "hardware-installing" ]
+      },
       "elements": {},
       "element_order": [
         [ "ipmi-configure"  ]

--- a/chef/data_bags/crowbar/bc-template-ipmi.schema
+++ b/chef/data_bags/crowbar/bc-template-ipmi.schema
@@ -17,6 +17,12 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": { "type": "map", "mapping": {
+                = : { "type": "seq", "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": { "type": "map", "required": true, "mapping": {
                 = : {  "type": "seq", "required": true,
                   "sequence": [ { "type": "str" } ]


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-ipmi.json   |    3 +++
 chef/data_bags/crowbar/bc-template-ipmi.schema |    6 ++++++
 2 files changed, 9 insertions(+), 0 deletions(-)
