### PR TITLE
Make sure sledgehammer syncs and umounts filesystems before shutting down. [1/6]

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
@@ -81,7 +81,7 @@ if node[:ipmi][:bmc_enable]
       [ "Default VLAN", "ipmitool lan set 1 vlan id #{bmc_vlan}", bmc_vlan, 10 ]
     ]
 
-    lan_params << [ "Default Gateway IP", "ipmitool lan set 1 defgw ipaddr #{bmc_router}", bmc_router, 1 ] unless bmc_router.nil?
+    lan_params << [ "Default Gateway IP", "ipmitool lan set 1 defgw ipaddr #{bmc_router}", bmc_router, 1 ] unless bmc_router.nil? || bmc_router.empty?
 
     lan_params.each do |param| 
       ipmi_lan_set "#{param[0]}" do


### PR DESCRIPTION
This should help keep us from losing the logs from Sledgehammer.

Along the way, fix up a bug that was trying to assign a default route to 
the BMC even though bmc_router was the empty string, and add a couple of useful
options to the test framework for running in mixed virtual and physical
environments.

 chef/cookbooks/ipmi/recipes/ipmi-configure.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
