### PR TITLE
Add online mode for the provisioner and experimental online-install functionality [3/10]

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
@@ -30,14 +30,15 @@ unless ::File.exists?("/usr/sbin/ipmitool") or ::File.exists?("/usr/bin/ipmitool
   end
 end
 
-unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platform", "VirtualBox" ]
+unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platform", "VirtualBox", "Unknown" ]
 
 if node[:ipmi][:bmc_enable]
-  if unsupported.member?(node[:dmi][:system][:product_name])
+  platform = (node[:dmi][:system][:product_name] rescue "Unknown")
+  if unsupported.member?(platform)
     node["crowbar_wall"] = {} unless node["crowbar_wall"]
     node["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
     node["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
+    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{platform} - turning off ipmi for this node" ]
     node[:ipmi][:bmc_enable] = false
     node.save
     return


### PR DESCRIPTION
This pull request series add 2 new features to Crowbar:

 1: Online mode for the provisioner.
    This enables the provisioner to be able to update deb/rpm/gem
    packages from sources on the Internet.

```
See README.package-updates for details on how this works and how
to enable it.
```

 2: Experimental full online-install mode.
    This leverages the infrastructure added for the provisioner to
    allow for installation of an admin node starting with a basic OS
    install and a checkout of the main Crowbar repository.  This is
    mainly useful right node for development purposes, and is under
    active development.  Most things work, but expect weird corner
    cases.

```
See README.online-install for more details.
```
