### PR TITLE
re-factor out intialize method in controllers [4/22]

### DIFF
--- a/crowbar_framework/app/controllers/ipmi_controller.rb
+++ b/crowbar_framework/app/controllers/ipmi_controller.rb
@@ -14,7 +14,11 @@
 # 
 
 class IpmiController < BarclampController
-  def initialize
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = IpmiService.new logger
   end
+
+  private :set_service_object
 end


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/ipmi_controller.rb             |   44 +++++++++++---------
 1 files changed, 24 insertions(+), 20 deletions(-)
