### PR TITLE
Refactoring step 2 - linking Roles and Attribs [2/3]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,10 +26,20 @@ crowbar:
   run_order: 16
   chef_order: 16
 
+orchestration:
+  mode: full
+  transitions:
+    - discovering
+    - discovered
+  
 roles:
   'ipmi-configure':
-    unique: false
-    count: -1
+    order: 100
+    run_order: :auto
+    states:
+      - "hardware-installing"
+    node_unique: false
+    node_count: :unlimited
     attributes:
       'bmc_enable':
         default: true
@@ -42,7 +52,7 @@ roles:
         chef: "impi/bmc_password"
       "debug": 
         default: true
-        chef: "impi//debug"
+        chef: "impi/debug"
   ipmi-discover:
     unique: false
     count: -1


### PR DESCRIPTION
This is a major step forward in the refactoring effort.

In this pass, we linked the RoleInstances to AttribInstances.  This allows use to store
data in a way that can be consumed by Jigs.

In order to make inbound data processing work, we have to track maps to the different jigs.
This had been hardcoded and had to be moved into a dedicated table.  I made the decision
to have this at the barclamp/jig level rather than at the instance level.

Pending changes are needed to resolve times when we have a time series of data in the 
AttributeInstance data.  In the next stage, we will need to select the active instance data
for Attribs and not return all of them.

Some significant developments in this pull are
- process-inbound data works correctly
- attribuate are created from the bc-template files (that's moving to crowbar.yml)
- roles are create from the bc-template files (that's also moving)
- barclamp-attrib-maps are stored in a dedicated table
- example of the role/attrib data in the impi crowbar.yml

One important note: it looks like we are moving to a place where Attribs MUST have a role assigned.  
This is a simplifying assumption that we will start enforcing in the next pull request.

The next step is to replace the NodeRole and move it to AttribInst

 crowbar.yml |   35 ++++++++++++++++++++++++++++++++---
 1 file changed, 32 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: d5070acd86c8ba863774a27e016b5327e7e0e41e

Crowbar-Release: development
