### PR TITLE
Fixups to add enough default attributes to some roles to test them on an admin node. [1/7]

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
@@ -42,12 +42,12 @@ bmc_vlan     = if bmc_use_vlan
                  "off"
                end
 
-node["crowbar_wall"] = {} if node["crowbar_wall"].nil?
-node["crowbar_wall"]["status"] = {} if node["crowbar_wall"]["status"].nil?
+node.set["crowbar_wall"] = {} if node["crowbar_wall"].nil?
+node.set["crowbar_wall"]["status"] = {} if node["crowbar_wall"]["status"].nil?
 if node["crowbar_wall"]["status"]["ipmi"].nil?
-  node["crowbar_wall"]["status"]["ipmi"] = {}
-  node["crowbar_wall"]["status"]["ipmi"]["user_set"] = false
-  node["crowbar_wall"]["status"]["ipmi"]["address_set"] = false
+  node.set["crowbar_wall"]["status"]["ipmi"] = {}
+  node.set["crowbar_wall"]["status"]["ipmi"]["user_set"] = false
+  node.set["crowbar_wall"]["status"]["ipmi"]["address_set"] = false
   node.save
 end
 
@@ -55,14 +55,14 @@ unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platf
 
 if node[:ipmi][:bmc_enable]
   if unsupported.member?(node[:dmi][:system][:product_name])
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
-    node[:ipmi][:bmc_enable] = false
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
+    node.set[:ipmi][:bmc_enable] = false
     node.save
     return
   end
 
   unless (node["crowbar_wall"]["status"]["ipmi"]["address_set"] and node["crowbar_wall"]["status"]["ipmi"]["user_set"])
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = []
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = []
     node.save
 
     ipmi_load "ipmi_load" do

--- a/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
@@ -35,11 +35,11 @@ unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platf
 if node[:ipmi][:bmc_enable]
   platform = (node[:dmi][:system][:product_name] rescue "Unknown")
   if unsupported.member?(platform)
-    node["crowbar_wall"] = {} unless node["crowbar_wall"]
-    node["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
-    node["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{platform} - turning off ipmi for this node" ]
-    node[:ipmi][:bmc_enable] = false
+    node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
+    node.set["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
+    node.set["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{platform} - turning off ipmi for this node" ]
+    node.set[:ipmi][:bmc_enable] = false
     node.save
     return
   end
@@ -47,19 +47,19 @@ if node[:ipmi][:bmc_enable]
   %x{modprobe ipmi_si ; modprobe ipmi_devintf ; sleep 15}
   %x{ipmitool lan print 1 > /tmp/lan.print}
   if $?.exitstatus == 0
-    node["crowbar_wall"] = {} unless node["crowbar_wall"]
-    node["crowbar_wall"]["ipmi"] = {} unless node["crowbar_wall"]["ipmi"]
-    node["crowbar_wall"]["ipmi"]["address"] = %x{grep "IP Address   " /tmp/lan.print | awk -F" " '\{print $4\}'}.strip
-    node["crowbar_wall"]["ipmi"]["gateway"] = %x{grep "Default Gateway IP " /tmp/lan.print | awk -F" " '\{ print $5 \}'}.strip
-    node["crowbar_wall"]["ipmi"]["netmask"] = %x{grep "Subnet Mask" /tmp/lan.print | awk -F" " '\{ print $4 \}'}.strip
-    node["crowbar_wall"]["ipmi"]["mode"] = %x{ipmitool delloem lan get}.strip
+    node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
+    node.set["crowbar_wall"]["ipmi"] = {} unless node["crowbar_wall"]["ipmi"]
+    node.set["crowbar_wall"]["ipmi"]["address"] = %x{grep "IP Address   " /tmp/lan.print | awk -F" " '\{print $4\}'}.strip
+    node.set["crowbar_wall"]["ipmi"]["gateway"] = %x{grep "Default Gateway IP " /tmp/lan.print | awk -F" " '\{ print $5 \}'}.strip
+    node.set["crowbar_wall"]["ipmi"]["netmask"] = %x{grep "Subnet Mask" /tmp/lan.print | awk -F" " '\{ print $4 \}'}.strip
+    node.set["crowbar_wall"]["ipmi"]["mode"] = %x{ipmitool delloem lan get}.strip
     node.save
   else
-    node["crowbar_wall"] = {} unless node["crowbar_wall"]
-    node["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
-    node["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Could not get IPMI lan info: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
-    node[:ipmi][:bmc_enable] = false
+    node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
+    node.set["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
+    node.set["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Could not get IPMI lan info: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
+    node.set[:ipmi][:bmc_enable] = false
     node.save
     return
   end


### PR DESCRIPTION
Aside from Chef 11 fixups, the default attributes are inteded to be a
placeholder until the chef jig is working well enough to handle
attribute import and export.

Roles that have been validated so far are:
- deployer-client
- dns-client
- ntp-server
- logging-server

Roles that have been half-validated (recipes run without error, but
functionality is missing:
- bmc-nat-router: Needs the network BC to have injected attributed
  for the networks onto the node.
- dns-server: Ditto

Roles that have nbeen modified, but not tested:
- logging-client:  Cannot test until we have another node, as
  logging-client and logging-server cannot coexist on the same node.
- ipmi-discover and ipmi-configure: Need real hardware to
  meaningfully test these barclamps.
- provisioner-base and provisioner-server:  Need a semi-functional
  DNS server and network BC to make any reasonable progress here.
  
  chef/cookbooks/ipmi/recipes/ipmi-configure.rb |   16 ++++++-------
  chef/cookbooks/ipmi/recipes/ipmi-discover.rb  |   32 ++++++++++++-------------
  2 files changed, 24 insertions(+), 24 deletions(-)

Crowbar-Pull-ID: c57e28f294ea94c640dee96a8a8c4ce5db59bb8e

Crowbar-Release: development
