### PR TITLE
Add enough default attributes to some roles to test them on an admin server. [1/7]

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
@@ -42,12 +42,12 @@ bmc_vlan     = if bmc_use_vlan
                  "off"
                end
 
-node["crowbar_wall"] = {} if node["crowbar_wall"].nil?
-node["crowbar_wall"]["status"] = {} if node["crowbar_wall"]["status"].nil?
+node.set["crowbar_wall"] = {} if node["crowbar_wall"].nil?
+node.set["crowbar_wall"]["status"] = {} if node["crowbar_wall"]["status"].nil?
 if node["crowbar_wall"]["status"]["ipmi"].nil?
-  node["crowbar_wall"]["status"]["ipmi"] = {}
-  node["crowbar_wall"]["status"]["ipmi"]["user_set"] = false
-  node["crowbar_wall"]["status"]["ipmi"]["address_set"] = false
+  node.set["crowbar_wall"]["status"]["ipmi"] = {}
+  node.set["crowbar_wall"]["status"]["ipmi"]["user_set"] = false
+  node.set["crowbar_wall"]["status"]["ipmi"]["address_set"] = false
   node.save
 end
 
@@ -55,14 +55,14 @@ unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platf
 
 if node[:ipmi][:bmc_enable]
   if unsupported.member?(node[:dmi][:system][:product_name])
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
-    node[:ipmi][:bmc_enable] = false
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
+    node.set[:ipmi][:bmc_enable] = false
     node.save
     return
   end
 
   unless (node["crowbar_wall"]["status"]["ipmi"]["address_set"] and node["crowbar_wall"]["status"]["ipmi"]["user_set"])
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = []
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = []
     node.save
 
     ipmi_load "ipmi_load" do

--- a/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
@@ -35,11 +35,11 @@ unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platf
 if node[:ipmi][:bmc_enable]
   platform = (node[:dmi][:system][:product_name] rescue "Unknown")
   if unsupported.member?(platform)
-    node["crowbar_wall"] = {} unless node["crowbar_wall"]
-    node["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
-    node["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{platform} - turning off ipmi for this node" ]
-    node[:ipmi][:bmc_enable] = false
+    node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
+    node.set["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
+    node.set["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{platform} - turning off ipmi for this node" ]
+    node.set[:ipmi][:bmc_enable] = false
     node.save
     return
   end
@@ -47,19 +47,19 @@ if node[:ipmi][:bmc_enable]
   %x{modprobe ipmi_si ; modprobe ipmi_devintf ; sleep 15}
   %x{ipmitool lan print 1 > /tmp/lan.print}
   if $?.exitstatus == 0
-    node["crowbar_wall"] = {} unless node["crowbar_wall"]
-    node["crowbar_wall"]["ipmi"] = {} unless node["crowbar_wall"]["ipmi"]
-    node["crowbar_wall"]["ipmi"]["address"] = %x{grep "IP Address   " /tmp/lan.print | awk -F" " '\{print $4\}'}.strip
-    node["crowbar_wall"]["ipmi"]["gateway"] = %x{grep "Default Gateway IP " /tmp/lan.print | awk -F" " '\{ print $5 \}'}.strip
-    node["crowbar_wall"]["ipmi"]["netmask"] = %x{grep "Subnet Mask" /tmp/lan.print | awk -F" " '\{ print $4 \}'}.strip
-    node["crowbar_wall"]["ipmi"]["mode"] = %x{ipmitool delloem lan get}.strip
+    node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
+    node.set["crowbar_wall"]["ipmi"] = {} unless node["crowbar_wall"]["ipmi"]
+    node.set["crowbar_wall"]["ipmi"]["address"] = %x{grep "IP Address   " /tmp/lan.print | awk -F" " '\{print $4\}'}.strip
+    node.set["crowbar_wall"]["ipmi"]["gateway"] = %x{grep "Default Gateway IP " /tmp/lan.print | awk -F" " '\{ print $5 \}'}.strip
+    node.set["crowbar_wall"]["ipmi"]["netmask"] = %x{grep "Subnet Mask" /tmp/lan.print | awk -F" " '\{ print $4 \}'}.strip
+    node.set["crowbar_wall"]["ipmi"]["mode"] = %x{ipmitool delloem lan get}.strip
     node.save
   else
-    node["crowbar_wall"] = {} unless node["crowbar_wall"]
-    node["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
-    node["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
-    node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Could not get IPMI lan info: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
-    node[:ipmi][:bmc_enable] = false
+    node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
+    node.set["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
+    node.set["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
+    node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Could not get IPMI lan info: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
+    node.set[:ipmi][:bmc_enable] = false
     node.save
     return
   end


### PR DESCRIPTION
Roles that have been tested:

roles for server:
   deployer-client -- OK
   bmc-nat-router -- OK
   dns-server -- tested, will need network bc.
   dns-client -- OK
   ntp-server -- OK
   logging-server -- OK
   logging-client -- not tested, cannot run with logging-server
   ipmi-discover -- not tested, need real hardware
   ipmi-configure -- not tested, need real hardware
   provisioner-base -- not tested, need working DNS and network.
   provisioner-server -- Not tested, need working DNS and network.

 chef/cookbooks/ipmi/recipes/ipmi-configure.rb |   16 ++++++-------
 chef/cookbooks/ipmi/recipes/ipmi-discover.rb  |   32 ++++++++++++-------------
 2 files changed, 24 insertions(+), 24 deletions(-)

Crowbar-Pull-ID: b29260d1a62efa73a3928f732a6a1e5316498543

Crowbar-Release: development
