### PR TITLE
Added "unsupported" platform "Unknown"

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
@@ -51,10 +51,11 @@ if node["crowbar_wall"]["status"]["ipmi"].nil?
   node.save
 end
 
-unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platform", "VirtualBox" ]
+unsupported = [ "KVM", "Bochs", "VMWare Virtual Platform", "VMware Virtual Platform", "VirtualBox", "Unknown" ]
 
 if node[:ipmi][:bmc_enable]
-  if unsupported.member?(node[:dmi][:system][:product_name])
+  platform = (node[:dmi][:system][:product_name] rescue "Unknown")
+  if unsupported.member?(platform)
     node.set["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Unsupported platform: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
     node.set[:ipmi][:bmc_enable] = false
     node.save


### PR DESCRIPTION
Default to it if ohai doesn't return anything useful. This is to make crowbar
work on paravirtualized Xen guests. Which doesn't set a useful product_name.

This is a forward port of a patch that SUSE had in the crowbar-barclamp-ipmi packages for the crowbar 1.0 based release. 
