### PR TITLE
Turn down default logging verbosity for glance, ipmi, swift, and keystone. [2/4]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ipmi.json
+++ b/chef/data_bags/crowbar/bc-template-ipmi.json
@@ -8,7 +8,7 @@
 	  "bmc_password": "cr0wBar!",
       "ignore_address_suggestions": false,
       "use_dhcp": false,
-	  "debug": true
+	  "debug": false
 	 }
   },
   "deployment": {


### PR DESCRIPTION
We were being too verbose in our logging by default.  This pull
request turns down the volume so we don't drown in logfiles quite so fast.

 chef/data_bags/crowbar/bc-template-ipmi.json |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 898b27a701f199b0536ae0303358a67f6f08c00f

Crowbar-Release: pebbles
