### PR TITLE
Do not use return in ruby_block

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
@@ -55,16 +55,15 @@ if node[:ipmi][:bmc_enable]
         node["crowbar_wall"]["ipmi"]["gateway"] = %x{grep "Default Gateway IP " /tmp/lan.print | awk -F" " '\{ print $5 \}'}.strip
         node["crowbar_wall"]["ipmi"]["netmask"] = %x{grep "Subnet Mask" /tmp/lan.print | awk -F" " '\{ print $4 \}'}.strip
         node["crowbar_wall"]["ipmi"]["mode"] = %x{ipmitool delloem lan get}.strip
-        node.save
       else
         node["crowbar_wall"] = {} unless node["crowbar_wall"]
         node["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
         node["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
         node["crowbar_wall"]["status"]["ipmi"]["messages"] = [ "Could not get IPMI lan info: #{node[:dmi][:system][:product_name]} - turning off ipmi for this node" ]
         node[:ipmi][:bmc_enable] = false
-        node.save
-        return
       end
+
+      node.save
 
       %x{rmmod ipmi_si ; rmmod ipmi_devintf ; rmmod ipmi_msghandler}
     end


### PR DESCRIPTION
This is not needed, and this creates the following error:
## LocalJumpError

unexpected return
## Cookbook Trace:

/var/chef/cache/cookbooks/ipmi/recipes/ipmi-discover.rb:66:in `from_file'

Note that there's nothing after the ruby_block anyway, so the intent of
return is still preserved.
