### PR TITLE
Make jigs even more late-bound. [2/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -31,38 +31,6 @@ crowbar:
   layout: 2.0
   order: 16
 
-
-orchestration:
-  mode: full
-  transitions:
-    - discovering
-    - discovered
-  
-roles:
-  'ipmi-configure':
-    order: 100
-    run_order: :auto
-    states:
-      - "hardware-installing"
-    node_unique: false
-    node_count: :unlimited
-    attributes:
-      'bmc_enable':
-        default: true
-        chef: 'impi/bmc_enable'
-      'bmc_user':
-        default: root
-        chef: "impi/bmc_user"
-      "bmc_password": 
-        default: crowbar
-        chef: "impi/bmc_password"
-      "debug": 
-        default: true
-        chef: "impi/debug"
-  ipmi-discover:
-    unique: false
-    count: -1
-
 debs:
   pkgs:
     - ipmitool


### PR DESCRIPTION
This pull request series makes jigs even more late bound, and reworks
how roles are defined and loaded from crowbar.yml to make it a
seperate section from the to-be-written jigs section, as the jigs
section should concern itself with declaring what (if any) jigs a
barclamp provides.

 crowbar.yml |   32 --------------------------------
 1 file changed, 32 deletions(-)

Crowbar-Pull-ID: b068d7f10391d12115dc134ecb5708d4b046de93

Crowbar-Release: development
