### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/app/controllers/ipmi_controller.rb
+++ b/crowbar_framework/app/controllers/ipmi_controller.rb
@@ -14,7 +14,10 @@
 # 
 
 class IpmiController < BarclampController
-  def initialize
+
+  protected
+
+  def initialize_service
     @service_object = IpmiService.new logger
   end
 end


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.
**This depends on https://github.com/crowbar/barclamp-crowbar/pull/1036**
