### PR TITLE
Allow the admin node for ipmi-configure/discover

### DIFF
--- a/crowbar_framework/app/models/ipmi_service.rb
+++ b/crowbar_framework/app/models/ipmi_service.rb
@@ -25,6 +25,7 @@ class IpmiService < ServiceObject
       {
         "ipmi-configure" => {
           "unique" => false,
+          "admin" => true,
           "count" => -1
         }
       }


### PR DESCRIPTION
By default it seems the admin node is included in the
proposal, but when you try to save/apply it, you get
the error message that the proposal cannot be saved/applied
due to the role not being valid for admin. Since the
admin node has a central role here it seems, we should
allow it.
