### PR TITLE
Fix setting the route for BMC network through NAT (bsc#795603)

### DIFF
--- a/chef/cookbooks/bmc-nat/recipes/client.rb
+++ b/chef/cookbooks/bmc-nat/recipes/client.rb
@@ -28,7 +28,9 @@ nat_address = nat_node[:crowbar][:network][:admin][:address]
 
 return if admin_subnet == bmc_subnet && admin_netmask == bmc_netmask
 
+bmc_cidr = IP::IP4.netmask_to_subnet(bmc_netmask)
+
 bash "Add route to get to our BMC via nat" do
-  code "ip route add #{bmc_subnet}/#{bmc_netmask} via #{nat_address}"
+  code "ip route add #{bmc_subnet}/#{bmc_cidr} via #{nat_address}"
   not_if "ip route show via #{nat_address} |grep -q #{bmc_subnet}"
 end

--- a/chef/cookbooks/bmc-nat/recipes/client.rb
+++ b/chef/cookbooks/bmc-nat/recipes/client.rb
@@ -32,5 +32,5 @@ bmc_cidr = IP::IP4.netmask_to_subnet(bmc_netmask)
 
 bash "Add route to get to our BMC via nat" do
   code "ip route add #{bmc_subnet}/#{bmc_cidr} via #{nat_address}"
-  not_if "ip route show via #{nat_address} |grep -q #{bmc_subnet}"
+  not_if "ip route show via #{nat_address} |grep -q #{bmc_subnet}/#{bmc_cidr}"
 end


### PR DESCRIPTION
We were not using a CIDR notation when calling "ip route", which was
breaking.

https://bugzilla.suse.com/show_bug.cgi?id=795603